### PR TITLE
chore: bump glob dependency to 11.1.0

### DIFF
--- a/packages/knowhow/package.json
+++ b/packages/knowhow/package.json
@@ -53,7 +53,7 @@
     "diff": "^5.2.0",
     "express": "^4.19.2",
     "gitignore-to-glob": "^0.3.0",
-    "glob": "11.0.3",
+    "glob": "11.1.0",
     "isolated-vm": "^5.0.4",
     "jiti": "^2.6.1",
     "marked": "^10.0.0",


### PR DESCRIPTION
Updates `packages/knowhow` to use `glob` version `11.1.0` instead of `11.0.3`.

### Why
Keeping dependencies current helps ensure compatibility with the latest fixes and improvements provided by the upstream `glob` package.